### PR TITLE
Consistent node names in graph xml and loadtest csv

### DIFF
--- a/data/Sock-shop-xml.txt
+++ b/data/Sock-shop-xml.txt
@@ -1,55 +1,62 @@
 <?xml version="1.0"?>
 <cluster>
- <vertex id="master"/>
-   <vertex id="worker1">
-       <adjacent vertex="master"/>
-   </vertex>
-   <vertex id="worker2">
-       <adjacent vertex="master"/>
-   </vertex>
-    <vertex id="frontend"><adjacent vertex="worker2"/></vertex>
-    <vertex id="order"> 
-        <adjacent vertex="frontend"/>
-        <adjacent vertex="shipping"/>
-        <adjacent vertex="worker1"/>
+    <vertex id="master" />
+    <vertex id="worker1">
+        <adjacent vertex="master" />
+    </vertex>
+    <vertex id="worker2">
+        <adjacent vertex="master" />
+    </vertex>
+    <vertex id="front-end">
+        <adjacent vertex="worker2" />
+    </vertex>
+    <vertex id="orders">
+        <adjacent vertex="front-end" />
+        <adjacent vertex="shipping" />
+        <adjacent vertex="worker1" />
     </vertex>
     <vertex id="payment">
-        <adjacent vertex="frontend"/>  
-        <adjacent vertex="worker1"/>
+        <adjacent vertex="worker1" />
     </vertex>
-    <vertex id="cart">
-         <adjacent vertex="frontend"/>
-          <adjacent vertex="worker1"/>
+    <vertex id="carts">
+        <adjacent vertex="front-end" />
+        <adjacent vertex="worker1" />
     </vertex>
-     <vertex id="user">
-         <adjacent vertex="frontend"/>
-         <adjacent vertex="worker1"/>
+    <vertex id="user">
+        <adjacent vertex="front-end" />
+        <adjacent vertex="worker1" />
+        <adjacent vertex="user-db" />
+    </vertex>
+    <vertex id="user-db">
+        <adjacent vertex="worker2" />
     </vertex>
     <vertex id="catalogue">
-        <adjacent vertex="frontend"/>
-         <adjacent vertex="worker1"/>
+        <adjacent vertex="front-end" />
+        <adjacent vertex="worker1" />
     </vertex>
-     <vertex id="catalogue-db"> 
-        <adjacent vertex="catalogue"/> 
-         <adjacent vertex="worker1"/>
-    </vertex>  
-    <vertex id="order-db"> 
-        <adjacent vertex="order"/> 
-         <adjacent vertex="worker2"/>
-    </vertex> 
-    <vertex id="cart-db"> 
-        <adjacent vertex="cart"/> 
-        <adjacent vertex="worker2"/>
-    </vertex> 
-     <vertex id="shipping">
-         <adjacent vertex="worker1"/>
-         <adjacent vertex="queuemaster2"/>
+    <vertex id="catalogue-db">
+        <adjacent vertex="catalogue" />
+        <adjacent vertex="worker1" />
     </vertex>
-    <vertex id="queuemaster">
-         <adjacent vertex="worker1"/>
+    <vertex id="orders-db">
+        <adjacent vertex="orders" />
+        <adjacent vertex="worker2" />
     </vertex>
-    <vertex id="sessiondb">
-         <adjacent vertex="worker2"/>
+    <vertex id="carts-db">
+        <adjacent vertex="carts" />
+        <adjacent vertex="worker2" />
     </vertex>
-       
+    <vertex id="shipping">
+        <adjacent vertex="worker1" />
+        <adjacent vertex="queue-master" />
+    </vertex>
+    <vertex id="queue-master">
+        <adjacent vertex="worker1" />
+    </vertex>
+    <vertex id="rabbitmq">
+        <adjacent vertex="worker1" />
+    </vertex>
+    <vertex id="session-db">
+        <adjacent vertex="worker2" />
+    </vertex>
 </cluster>


### PR DESCRIPTION
In order to map metrics to the graph, the node names are changed to match the column names. Additionally, the node user-db was added as it was missing, and some vertices were corrected to match the knowledge graph JPG.